### PR TITLE
CALENDAR | changed the add to calendar flow by added more feedback

### DIFF
--- a/src/components/concert_page/concert.jsx
+++ b/src/components/concert_page/concert.jsx
@@ -335,7 +335,7 @@ const Concert = (props) => {
         document.getElementById("calendar-redirect-msg").style.visibility =
           "hidden";
       }
-        setStubAnimationDone(true);
+      setStubAnimationDone(true);
       // Go back to the concert page after half a second
       setTimeout(() => {
         setShowStub(false);
@@ -391,7 +391,7 @@ const Concert = (props) => {
         if (result.status === 200) {
           setCalenderAdded(true);
           setCalendarBtnClicked(false);
-          console.log(concert_info.date)
+          console.log(concert_info.date);
           // animationEnd();
         }
       })
@@ -429,7 +429,7 @@ const Concert = (props) => {
                               className="calendar-redirect-msg"
                               id="calendar-redirect-msg"
                             >
-                              This event has been added to your calendar! Go to{" "}
+                              We've got you covered! Check your{" "}
                               <a
                                 href={
                                   "https://calendar.google.com/calendar/b/0/r/week/" +
@@ -437,9 +437,9 @@ const Concert = (props) => {
                                 }
                                 target="_blank"
                               >
-                                google calendar
+                                Google Calendar
                               </a>{" "}
-                              to confirm!
+                              for a surprise.
                             </p>
                           ) : calendar_button_clicked ? (
                             <div className="moonloader-container">
@@ -912,7 +912,7 @@ const Concert = (props) => {
                               className="calendar-redirect-msg"
                               id="calendar-redirect-msg"
                             >
-                              This event has been added to your calendar! Go to{" "}
+                              We've got you covered! Check your{" "}
                               <a
                                 href={
                                   "https://calendar.google.com/calendar/b/0/r/week/" +
@@ -920,9 +920,9 @@ const Concert = (props) => {
                                 }
                                 target="_blank"
                               >
-                                google calendar
+                                Google Calendar
                               </a>{" "}
-                              to confirm!
+                              for a surprise.
                             </p>
                           ) : calendar_button_clicked ? (
                             <div className="moonloader-container">

--- a/src/components/concert_page/concert_styles.scss
+++ b/src/components/concert_page/concert_styles.scss
@@ -87,6 +87,8 @@
 .calendar-redirect-msg {
   color: white;
   visibility: visible;
+  font-weight: 500;
+  font-size: 20px;
 }
 
 .moonloader-container {


### PR DESCRIPTION
Changed the add to calendar flow:
- remove the 8 seconds time-out for the ticket stub to disappear so that the ticket stub will always be present unless users click away
- once users click on "add to calendar" button, the button will changed to a moon-loader and the log-in to google page will be opened on another tab (the google login page will always show up even if the users have already logged in before)
- after users sign in with their google accounts and grant onfour access for their google calendar, the event will be added and the moon-loader will change to a message that will redirect them to open their google calendar page (the opened calendar should shows the week of the event being added!)
- users can click anywhere on the page to exit the modal

Things to change potentially:
- change the redirect message to be more playful
- add a close button on the ticket stub modal