### PR TITLE
BUG | rsvp email is case-insensitive

### DIFF
--- a/src/components/concert_page/concert.jsx
+++ b/src/components/concert_page/concert.jsx
@@ -436,7 +436,7 @@ const Concert = (props) => {
     }
 
     const concert_rsvp_info = await getOneConcert(concert_id);
-    const rsvp_list = [...concert_rsvp_info.rsvp_list, email];
+    const rsvp_list = [...concert_rsvp_info.rsvp_list, email.toLowerCase()];
 
     const concert_payload = {
       id: concert_id,

--- a/src/components/stream_page/access_modal.jsx
+++ b/src/components/stream_page/access_modal.jsx
@@ -17,8 +17,7 @@ const AccessModal = (props) => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    props.checkAccess(email_input.value);
-    console.log(email_input);
+    props.checkAccess(email_input.value.toLowerCase());
   };
   return (
     <div>

--- a/src/components/stream_page/ticket_modal.jsx
+++ b/src/components/stream_page/ticket_modal.jsx
@@ -92,7 +92,7 @@ const TicketModal = (props) => {
     }
 
     const concert_rsvp_info = await getOneConcert(props.concert_info.id);
-    const rsvp_list = [...concert_rsvp_info.rsvp_list, email];
+    const rsvp_list = [...concert_rsvp_info.rsvp_list, email.toLowerCase()];
 
     const concert_payload = {
       id: props.concert_info.id,


### PR DESCRIPTION
TO TEST:
- RSVP for a show with an email, and make sure to use some form of capitalization (VINODKRISHNAM instead of vinodkrishnam, for example)
- when you get to the stream page, enter your email but with different capitalization (if you used VINODKRISHNAM to RSVP, try with vInOdKriShnAM or something like that)
- you should be able to access the stream regardless of capitalization as long as the email is the same